### PR TITLE
Correctly serialize class names in propagated comments

### DIFF
--- a/src/source/CppGenerator.scala
+++ b/src/source/CppGenerator.scala
@@ -139,7 +139,7 @@ class CppGenerator(spec: Spec) extends Generator(spec) {
 
       // Write code to the header file
       w.wl
-      writeDoc(w, c.doc)
+      writeDoc(w, c.doc, idCpp.ty, "cpp")
       w.wl(s"static ${constFieldType} ${idCpp.const(c.ident)}${constValue}")
     }
   }
@@ -206,13 +206,13 @@ class CppGenerator(spec: Spec) extends Generator(spec) {
         w.wl
         w.wl
       }
-      writeDoc(w, doc)
+      writeDoc(w, doc, idCpp.ty, "cpp")
       writeCppTypeParams(w, params)
       w.w("struct " + actualSelf + cppFinal).bracedSemi {
         generateHppConstants(w, r.consts)
         // Field definitions.
         for (f <- r.fields) {
-          writeDoc(w, f.doc)
+          writeDoc(w, f.doc, idCpp.ty, "cpp")
           w.wl(marshal.fieldType(f.ty) + " " + idCpp.field(f.ident) + ";")
         }
 
@@ -326,7 +326,7 @@ class CppGenerator(spec: Spec) extends Generator(spec) {
     val methodNamesInScope = i.methods.map(m => idCpp.method(m.ident))
 
     writeHppFile(ident, origin, refs.hpp, refs.hppFwds, w => {
-      writeDoc(w, doc)
+      writeDoc(w, doc, idCpp.ty, "cpp")
       writeCppTypeParams(w, typeParams)
       w.w(s"class $self").bracedSemi {
         w.wlOutdent("public:")

--- a/src/source/JavaGenerator.scala
+++ b/src/source/JavaGenerator.scala
@@ -94,7 +94,7 @@ class JavaGenerator(spec: Spec) extends Generator(spec) {
     }
 
     for (c <- consts) {
-      writeDoc(w, c.doc)
+      writeDoc(w, c.doc, idJava.ty, "java")
       javaAnnotationHeader.foreach(w.wl)
       marshal.nullityAnnotation(c.ty).foreach(w.wl)
 
@@ -112,11 +112,11 @@ class JavaGenerator(spec: Spec) extends Generator(spec) {
     val refs = new JavaRefs()
 
     writeJavaFile(ident, origin, refs.java, w => {
-      writeDoc(w, doc)
+      writeDoc(w, doc, idJava.ty, "java")
       javaAnnotationHeader.foreach(w.wl)
       w.w(s"${javaClassAccessModifierString}enum ${marshal.typename(ident, e)}").braced {
         for (o <- normalEnumOptions(e)) {
-          writeDoc(w, o.doc)
+          writeDoc(w, o.doc, idJava.ty, "java")
           w.wl(idJava.enum(o.ident) + ",")
         }
         w.wl(";")
@@ -141,7 +141,7 @@ class JavaGenerator(spec: Spec) extends Generator(spec) {
     writeJavaFile(ident, origin, refs.java, w => {
       val javaClass = marshal.typename(ident, i)
       val typeParamList = javaTypeParams(typeParams)
-      writeDoc(w, doc)
+      writeDoc(w, doc, idJava.ty, "java")
 
       javaAnnotationHeader.foreach(w.wl)
 
@@ -186,7 +186,7 @@ class JavaGenerator(spec: Spec) extends Generator(spec) {
             w.wl
           }
         }
-        
+
         if (i.ext.cpp) {
           w.wl
           javaAnnotationHeader.foreach(w.wl)
@@ -289,7 +289,7 @@ class JavaGenerator(spec: Spec) extends Generator(spec) {
     }
 
     writeJavaFile(javaName, origin, refs.java, w => {
-      writeDoc(w, doc)
+      writeDoc(w, doc, idJava.ty, "java")
       javaAnnotationHeader.foreach(w.wl)
       val self = marshal.typename(javaName, r)
 
@@ -329,7 +329,7 @@ class JavaGenerator(spec: Spec) extends Generator(spec) {
         // Accessors
         for (f <- r.fields) {
           w.wl
-          writeDoc(w, f.doc)
+          writeDoc(w, f.doc, idJava.ty, "java")
           marshal.nullityAnnotation(f.ty).foreach(w.wl)
           w.w("public " + marshal.returnType(Some(f.ty)) + " " + idJava.method("get_" + f.ident.name) + "()").braced {
             w.wl("return " + idJava.field(f.ident) + ";")

--- a/src/source/ObjcGenerator.scala
+++ b/src/source/ObjcGenerator.scala
@@ -50,7 +50,7 @@ class ObjcGenerator(spec: Spec) extends BaseObjcGenerator(spec) {
 
     val self = marshal.typename(ident, e)
     writeObjcFile(marshal.headerName(ident), origin, refs.header, w => {
-      writeDoc(w, doc)
+      writeDoc(w, doc, idJava.ty, "objc")
       w.wl(if(e.flags) {
         s"typedef NS_OPTIONS(NSUInteger, $self)"
       } else {
@@ -105,13 +105,13 @@ class ObjcGenerator(spec: Spec) extends BaseObjcGenerator(spec) {
     // Generate the header file for Interface
     writeObjcFile(marshal.headerName(ident), origin, refs.header, w => {
       for (c <- i.consts if marshal.canBeConstVariable(c)) {
-        writeDoc(w, c.doc)
+        writeDoc(w, c.doc, idJava.ty, "objc")
         w.w(s"extern ")
         writeObjcConstVariableDecl(w, c, self)
         w.wl(s";")
       }
       w.wl
-      writeDoc(w, doc)
+      writeDoc(w, doc, idJava.ty, "objc")
       if (i.ext.objc) w.wl(s"@protocol $self") else w.wl(s"@interface $self : NSObject")
       for (m <- i.methods) {
         w.wl
@@ -121,7 +121,7 @@ class ObjcGenerator(spec: Spec) extends BaseObjcGenerator(spec) {
       }
       for (c <- i.consts if !marshal.canBeConstVariable(c)) {
         w.wl
-        writeDoc(w, c.doc)
+        writeDoc(w, c.doc, idJava.ty, "objc")
         writeObjcConstMethDecl(c, w)
       }
       w.wl
@@ -171,7 +171,7 @@ class ObjcGenerator(spec: Spec) extends BaseObjcGenerator(spec) {
 
     // Generate the header file for record
     writeObjcFile(marshal.headerName(objcName), origin, refs.header, w => {
-      writeDoc(w, doc)
+      writeDoc(w, doc, idJava.ty, "objc")
       w.wl(s"@interface $self : NSObject")
 
       def writeInitializer(sign: String, prefix: String) {
@@ -185,13 +185,13 @@ class ObjcGenerator(spec: Spec) extends BaseObjcGenerator(spec) {
 
       for (c <- r.consts if !marshal.canBeConstVariable(c)) {
         w.wl
-        writeDoc(w, c.doc)
+        writeDoc(w, c.doc, idJava.ty, "objc")
         writeObjcConstMethDecl(c, w)
       }
 
       for (f <- r.fields) {
         w.wl
-        writeDoc(w, f.doc)
+        writeDoc(w, f.doc, idJava.ty, "objc")
         val nullability = marshal.nullability(f.ty.resolved).fold("")(", " + _)
         w.wl(s"@property (nonatomic, readonly${nullability}) ${marshal.fqFieldType(f.ty)} ${idObjc.field(f.ident)};")
       }
@@ -205,7 +205,7 @@ class ObjcGenerator(spec: Spec) extends BaseObjcGenerator(spec) {
       if (r.consts.nonEmpty) {
         w.wl
         for (c <- r.consts if marshal.canBeConstVariable(c)) {
-          writeDoc(w, c.doc)
+          writeDoc(w, c.doc, idJava.ty, "objc")
           w.w(s"extern ")
           writeObjcConstVariableDecl(w, c, noBaseSelf);
           w.wl(s";")


### PR DESCRIPTION
Java (javadoc) and Obj-C (jazzy) use different syntax for documentation links. This update to djinni correctly generates links to classes.  Regex is used do detect patterns "@see class_name" and "@link class_name" and transform it to corresponding documentation formats:

- @see currency_type:
  - @see CurrencyType (Java)
  - @see `ZKCurrencyType` (ObjectiveC)

- @link currency_type:
  - {@link CurrencyType CurrencyType} (Java)
  - `ZKCurrencyType` (ObjectiveC)