### PR TITLE
Fix class names not being correctly serialized in method descriptions

### DIFF
--- a/src/source/CppGenerator.scala
+++ b/src/source/CppGenerator.scala
@@ -337,7 +337,7 @@ class CppGenerator(spec: Spec) extends Generator(spec) {
         // Methods
         for (m <- i.methods) {
           w.wl
-          writeMethodDoc(w, m, idCpp.local)
+          writeMethodDoc(w, m, idCpp.local, idCpp.ty, "cpp")
           val ret = marshal.returnType(m.ret, methodNamesInScope)
           val params = m.params.map(p => marshal.paramType(p.ty, methodNamesInScope) + " " + idCpp.local(p.ident))
           if (m.static) {

--- a/src/source/JavaGenerator.scala
+++ b/src/source/JavaGenerator.scala
@@ -158,7 +158,7 @@ class JavaGenerator(spec: Spec) extends Generator(spec) {
         val throwException = spec.javaCppException.fold("")(" throws " + _)
         for (m <- i.methods if !m.static) {
           skipFirst { w.wl }
-          writeMethodDoc(w, m, idJava.local)
+          writeMethodDoc(w, m, idJava.local, idJava.ty, "java")
           val ret = marshal.returnType(m.ret)
           val params = m.params.map(p => {
             val nullityAnnotation = marshal.nullityAnnotation(p.ty).map(_ + " ").getOrElse("")
@@ -171,7 +171,7 @@ class JavaGenerator(spec: Spec) extends Generator(spec) {
         // Implement the interface's static methods as calls to CppProxy's corresponding methods.
         for (m <- i.methods if m.static) {
           skipFirst { w.wl }
-          writeMethodDoc(w, m, idJava.local)
+          writeMethodDoc(w, m, idJava.local, idJava.ty, "java")
           val ret = marshal.returnType(m.ret)
           val returnPrefix = if (ret == "void") "" else "return "
           val params = m.params.map(p => {

--- a/src/source/ObjcGenerator.scala
+++ b/src/source/ObjcGenerator.scala
@@ -115,7 +115,7 @@ class ObjcGenerator(spec: Spec) extends BaseObjcGenerator(spec) {
       if (i.ext.objc) w.wl(s"@protocol $self") else w.wl(s"@interface $self : NSObject")
       for (m <- i.methods) {
         w.wl
-        writeMethodDoc(w, m, idObjc.local)
+        writeMethodDoc(w, m, idObjc.local, idObjc.ty, "objc")
         writeObjcFuncDecl(m, w)
         w.wl(";")
       }

--- a/src/source/generator.scala
+++ b/src/source/generator.scala
@@ -424,13 +424,13 @@ abstract class Generator(spec: Spec)
 
   // --------------------------------------------------------------------------
 
-  def writeMethodDoc(w: IndentWriter, method: Interface.Method, ident: IdentConverter) {
+  def writeMethodDoc(w: IndentWriter, method: Interface.Method, ident: IdentConverter, identGlobal: IdentConverter, lang: String) {
     val paramReplacements = method.params.map(p => (s"\\b${Regex.quote(p.ident.name)}\\b", s"${ident(p.ident.name)}"))
     val newDoc = Doc(method.doc.lines.map(l => {
       paramReplacements.foldLeft(l)((line, rep) =>
         line.replaceAll(rep._1, rep._2))
     }))
-    writeDoc(w, newDoc, ident, "cpp")
+    writeDoc(w, newDoc, identGlobal, lang)
   }
 
   def writeDoc(w: IndentWriter, doc: Doc, ident: IdentConverter, lang: String) {


### PR DESCRIPTION
Missed the fact that method documentation is being serialized by a separate method from class documentation. 